### PR TITLE
Update Kroo warehouse guide on internal columns

### DIFF
--- a/methodology.mdx
+++ b/methodology.mdx
@@ -75,6 +75,21 @@ Here's how we process a typical RFI response from Procore:
 **Why This Approach?** This methodology ensures your data warehouse follows relational database best practices while maintaining all the rich detail from your construction management systems.
 </Info>
 
+### Understanding Internal Metadata Columns
+
+<Warning>
+**Important:** Any column in the Kroo warehouse that starts with an underscore (`_`) is internal metadata added by Kroo's data pipeline. These fields **did not come directly from your source system** and should generally not be used in your queries or reports.
+</Warning>
+
+**Common Internal Metadata Columns:**
+
+- **`_partner_id`** - Internal identifier used by Kroo's sync system
+- **`_data_type`** - Internal classification used for pipeline processing
+- **`_fivetran_deleted`** - Soft delete flag (exception: this field MUST be used in WHERE clauses)
+- **`_fivetran_synced`** - Timestamp of last sync operation
+
+**Best Practice:** When building queries and views, focus on the business columns that come from your source systems. The only internal metadata column you should regularly use is `_fivetran_deleted = 0` to filter out soft-deleted records.
+
 ## Sync Efficiency & Performance
 
 ### Smart Sync Strategies

--- a/methodology.mdx
+++ b/methodology.mdx
@@ -78,7 +78,7 @@ Here's how we process a typical RFI response from Procore:
 ### Understanding Internal Metadata Columns
 
 <Warning>
-**Important:** Any column in the Kroo warehouse that starts with an underscore (`_`) is internal metadata added by Kroo's data pipeline. These fields **did not come directly from your source system** and should generally not be used in your queries or reports.
+**Important:** Any column in the Kroo warehouse that starts with an underscore (`_`) is internal metadata added by Kroo's data pipeline. These fields **did not come directly from your source system**.
 </Warning>
 
 **Common Internal Metadata Columns:**
@@ -86,7 +86,6 @@ Here's how we process a typical RFI response from Procore:
 - **`_partner_id`** - Internal identifier used by Kroo's sync system
 - **`_data_type`** - Internal classification used for pipeline processing
 - **`_fivetran_deleted`** - Soft delete flag (exception: this field MUST be used in WHERE clauses)
-- **`_fivetran_synced`** - Timestamp of last sync operation
 
 **Best Practice:** When building queries and views, focus on the business columns that come from your source systems. The only internal metadata column you should regularly use is `_fivetran_deleted = 0` to filter out soft-deleted records.
 

--- a/sql-views-and-basics.mdx
+++ b/sql-views-and-basics.mdx
@@ -194,6 +194,22 @@ SELECT project_name, contract_amount
 FROM kroo_procore.projects
 ```
 
+### Understanding Internal Metadata Columns
+
+<Info>
+**Important:** Any column in the Kroo warehouse starting with an underscore (`_`) is internal metadata added by Kroo's data pipeline. These fields **did not come directly from your source system**.
+</Info>
+
+**Common Internal Metadata Columns to Avoid:**
+
+- **`_partner_id`** - Internal identifier used by Kroo's sync system (do not use in queries)
+- **`_data_type`** - Internal classification for pipeline processing (do not use in queries)
+- **`_fivetran_synced`** - Timestamp of last sync operation
+
+**Exception:** The `_fivetran_deleted` field is the only internal metadata column you should actively use in your queries - it's required to filter out soft-deleted records.
+
+**Best Practice:** When selecting columns for your views, focus on business data from your source systems and avoid internal metadata columns (except for the `_fivetran_deleted` filter in WHERE clauses).
+
 ## SQL Query Building Blocks
 
 Understanding the core SQL components will help you build effective views. Think of these as the essential ingredients in your data recipe.


### PR DESCRIPTION
Update guides to document internal metadata columns, clarifying that `_`-prefixed fields are internal and should generally be avoided in queries, with `_fivetran_deleted` being the only exception.

---
[Slack Thread](https://kroo-global.slack.com/archives/C09KEHSRYV6/p1760711117582699?thread_ts=1760711117.582699&cid=C09KEHSRYV6)

<a href="https://cursor.com/background-agent?bcId=bc-86c7da2e-cf6c-4a6f-b18c-3481e4ad4524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86c7da2e-cf6c-4a6f-b18c-3481e4ad4524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

