### PR TITLE
Ki docs updates

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,11 +8,6 @@
     "dark": "#15803D"
   },
   "favicon": "/favicon.ico",
-  "head": {
-    "links": [
-      { "rel": "stylesheet", "href": "/custom.css" }
-    ]
-  },
   "navigation": {
     "tabs": [
       {
@@ -51,6 +46,7 @@
             "pages": [
               "pipeline-analytics",
               "embed-dashboards",
+              "sync-schedule",
               "analytics-modules"
             ]
           },

--- a/kris-teams-bot.mdx
+++ b/kris-teams-bot.mdx
@@ -49,15 +49,19 @@ Download the Kris Teams bot app package:
 </Step>
 
 <Step title="Grant admin consent">
-  Open the following link in your browser to grant admin consent for Kris in your tenant:
+  Open the following link in your browser to grant admin consent for Kris in your tenant. Replace `[COMPANY_DOMAIN]` with your organization's Microsoft domain (e.g. `yourcompany.com`):
 
-  [Grant Admin Consent](https://login.microsoftonline.com/common/adminconsent?client_id=b3350ee0-1cf6-44e6-b4fb-284cf77b7eac&redirect_uri=https://getkroo.com)
+  [Grant Admin Consent](https://login.microsoftonline.com/[COMPANY_DOMAIN]/adminconsent?client_id=b3350ee0-1cf6-44e6-b4fb-284cf77b7eac&redirect_uri=https://getkroo.com)
 
   Sign in with your Microsoft 365 admin credentials and click **Accept** to approve the required permissions.
 
   <Info>
-  This one-time consent allows Kris to authenticate and operate within your organization. Without it, the bot will not be able to respond to user queries.
+  Kris verifies that the person messaging is a Kroo admin by reading their email address. Without this consent, Teams blocks the permission check and Kris will be unable to authenticate users or respond to queries.
   </Info>
+
+  <Warning>
+  This step must be completed by an **Azure AD administrator**. If the consent link returns an error, your Azure AD admin may need to enable third-party app consent in Azure AD settings first.
+  </Warning>
 </Step>
 </Steps>
 

--- a/record-deletion.mdx
+++ b/record-deletion.mdx
@@ -149,6 +149,28 @@ Soft-deleted records containing sensitive information are still present in your 
 </Card>
 </CardGroup>
 
+## Filtering Deleted Records Across Parent & Child Tables
+
+When a record is deleted in your source system, Kroo flags the **parent** record as deleted — but that flag does not automatically flow down to its **child** records. If you query a child table on its own, stale rows may still appear as active.
+
+To get accurate results, join the child table back to its parent and filter both:
+
+```sql
+SELECT
+    li.*
+FROM kroo_procore__direct_cost_line_items li
+INNER JOIN kroo_procore__direct_costs dc
+    ON li.direct_cost_id = dc.id
+WHERE dc._fivetran_deleted = 0
+  AND li._fivetran_deleted = 0
+```
+
+In this example, `kroo_procore__direct_costs` is the parent and `kroo_procore__direct_cost_line_items` is the child. The join ensures any line items belonging to a deleted direct cost are excluded from your results.
+
+<Info>
+Apply this pattern wherever you query child tables in Kroo. Using the parent as your anchor is the most reliable way to keep stale records out of your reports.
+</Info>
+
 ## Need Help?
 
 <Card title="Questions About Data Retention?" icon="question-circle">

--- a/sync-schedule.mdx
+++ b/sync-schedule.mdx
@@ -1,0 +1,46 @@
+---
+title: "Sync Schedule"
+description: "Configure how often your data pipelines sync and when they're allowed to run"
+icon: "clock"
+---
+
+The Sync Schedule controls how frequently Kroo pulls data from your connected sources, and optionally restricts syncs to specific times or days.
+
+## Basic Settings
+
+<CardGroup cols={2}>
+  <Card title="Time Denomination" icon="hourglass">
+    The unit of frequency for your sync — either **Hours** or **Days**
+  </Card>
+  <Card title="Interval" icon="repeat">
+    How often to sync within that unit — e.g. **Every 1** day syncs once daily
+  </Card>
+</CardGroup>
+
+## Advanced Settings
+
+Expand **Advanced settings (optional)** to access additional controls.
+
+<CardGroup cols={3}>
+  <Card title="Base Start Hour" icon="sun">
+    The time of day the sync cycle begins. Times are shown in **EDT**
+  </Card>
+  <Card title="Days of Week" icon="calendar-week">
+    Restrict syncs to specific weekdays. Leave all unchecked to allow any day
+  </Card>
+  <Card title="Days of Month" icon="calendar-days">
+    Restrict syncs to specific dates (1–31 or **Last day**). Leave unchecked to allow any date
+  </Card>
+</CardGroup>
+
+### Time Constraints
+
+Toggle **Time constraints** on to restrict syncs to specific windows. When active, syncs will only run during the days and times you configure.
+
+<Info>
+Time constraints are useful for avoiding syncs during business hours or limiting activity to overnight windows when API load is lower.
+</Info>
+
+## Support
+
+For help configuring your sync schedule, contact [implementations@getkroo.com](mailto:implementations@getkroo.com).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes (navigation and content) with no runtime or data-path impact; main risk is broken links or confusing instructions if the new consent URL placeholder is misused.
> 
> **Overview**
> Adds new documentation for configuring pipeline `Sync Schedule` (basic frequency plus optional day/time constraints) and links it into the Guides navigation.
> 
> Clarifies `Kris Teams Bot` setup by switching the admin-consent URL to a tenant-specific `[COMPANY_DOMAIN]` form and adding stronger rationale/warnings about required Azure AD admin consent.
> 
> Expands the soft-delete/retention guide with guidance and a SQL example for filtering deleted records when querying child tables by joining back to the parent and filtering both `_fivetran_deleted` flags. Also removes the custom CSS `head` link from `docs.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfddfa743783ff8b24a0b818606dda410db4c96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->