### PR TITLE
Add API Reference tab sourced from v3 OpenAPI

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -93,6 +93,10 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "API Reference",
+        "openapi": "https://api.getkroo.com/api/v3/openapi"
       }
     ],
     "global": {

--- a/docs.json
+++ b/docs.json
@@ -96,7 +96,7 @@
       },
       {
         "tab": "API Reference",
-        "openapi": "https://api.getkroo.com/api/v3/openapi"
+        "openapi": "https://api.getkroo.com/api/v3/openapi.yaml"
       }
     ],
     "global": {


### PR DESCRIPTION
## Summary

Adds an **API Reference** tab to Mintlify, sourced from kroo-api's live OpenAPI spec at `https://api.getkroo.com/api/v3/openapi.yaml`. Mintlify auto-generates endpoint pages from the spec, so the tab updates whenever kroo-api ships a new version — no docs PR needed for routine endpoint changes.

## Merge order

Land getkroo/kroo-api#2609 first (it adds the live endpoint). If this PR merges before kroo-api is deployed, Mintlify will fail to fetch the spec and the tab won't render.

## Follow-up (not blocking)

Mintlify only redeploys on git pushes, not on remote URL changes. A CI step in kroo-api that pings Mintlify's deploy-trigger API whenever `docs/openapi/v3.yaml` changes on `main` would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)