### PR TITLE
Show 'Event based' for frequency and next sync on webhook pipelines

### DIFF
--- a/pipeline-analytics.mdx
+++ b/pipeline-analytics.mdx
@@ -52,9 +52,9 @@ Below the utilization bar, a table lists every endpoint for the selected integra
 | Column | Description |
 |--------|-------------|
 | **Endpoint** | The name of the data pipeline (e.g., Accident logs, Budget views) |
-| **Sync Frequency** | How often the pipeline syncs (e.g., 1 day, 4 hours) |
+| **Sync Frequency** | How often the pipeline syncs (e.g., 1 day, 4 hours). Shows **Event based** for webhook-driven pipelines |
 | **Last Synced At** | Timestamp of the most recent successful sync |
-| **Next Sync At** | When the next sync is scheduled |
+| **Next Sync At** | When the next sync is scheduled. Shows **Event based** for webhook-driven pipelines |
 | **API Calls (24h)** | Total API calls made by this endpoint in the last 24 hours |
 
 Each row also has two actions on the right:


### PR DESCRIPTION
## Summary

- Updated the Pipeline Table description in `pipeline-analytics.mdx` to indicate that webhook-driven pipelines show **Event based** for both **Sync Frequency** and **Next Sync At** columns

https://claude.ai/code/session_01JPLWeKwhmkfSiNEHyLySr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPLWeKwhmkfSiNEHyLySr9)_