### PR TITLE
Add Kris section and AI focus to docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,9 @@ mint broken-links
 
 ### Documentation Structure
 The site uses a 3-tab navigation organized by user intent:
-- **Platform** tab: Overview (Welcome, Methodology), Data Lifecycle (Record Deletion, Table Snapshots, Historical Backfill), Two-Way Sync (Summary, ACC RFIs, ACC Submittals)
-- **Guides** tab: Analytics (SQL Views & Basics, Data Viewer), Integrations (P6/OPC File Uploads, Pipeline Status & PowerBI)
-- **Admin & Support** tab: Setup (Kris Teams Bot), Maintenance (Manual Data Refresh, Sage On-Prem Troubleshooting)
+- **Platform** tab: Overview (Welcome, Methodology, Meet Kris), Data Lifecycle (Record Deletion, Table Snapshots, Historical Backfill), Two-Way Sync (Summary, ACC RFIs, ACC Submittals)
+- **Guides** tab: Using the App (Pipeline Analytics, Embed Dashboards, Sync Schedule, Analytics Modules, Prompting Guidelines), Analytics (SQL Views & Basics, Data Viewer), Permissions, Integrations (P6/OPC File Uploads, Pipeline Status & PowerBI)
+- **Admin & Support** tab: Setup (Kris Teams Bot, Kroo MCP Setup, Windows Desktop App), Maintenance (Manual Data Refresh, Sage On-Prem Troubleshooting)
 
 ### Content Patterns
 - All content files use `.mdx` format (MDX = Markdown + JSX)

--- a/docs.json
+++ b/docs.json
@@ -17,14 +17,8 @@
             "group": "Overview",
             "pages": [
               "index",
-              "methodology"
-            ]
-          },
-          {
-            "group": "Kris",
-            "pages": [
-              "meet-kris",
-              "prompting-guidelines"
+              "methodology",
+              "meet-kris"
             ]
           },
           {
@@ -54,7 +48,8 @@
               "pipeline-analytics",
               "embed-dashboards",
               "sync-schedule",
-              "analytics-modules"
+              "analytics-modules",
+              "prompting-guidelines"
             ]
           },
           {
@@ -88,7 +83,7 @@
             "group": "Setup",
             "pages": [
               "kris-teams-bot",
-              "kris-mcp-setup",
+              "kroo-mcp-setup",
               "windows-desktop-app"
             ]
           },

--- a/docs.json
+++ b/docs.json
@@ -21,6 +21,13 @@
             ]
           },
           {
+            "group": "Kris",
+            "pages": [
+              "meet-kris",
+              "prompting-guidelines"
+            ]
+          },
+          {
             "group": "Data Lifecycle",
             "pages": [
               "record-deletion",

--- a/index.mdx
+++ b/index.mdx
@@ -20,8 +20,8 @@ Ask plain-English questions about your project data and get answers instantly
 <Card title="Risk Reduction" icon="shield-check">
 Make informed decisions with accurate, consistent, up-to-date data
 </Card>
-<Card title="Streamlined Workflows" icon="arrow-right">
-Eliminate manual data exports and reduce time spent on reporting
+<Card title="Permissions & Security" icon="key">
+Control who can access sensitive project data with secure, permission-aware views
 </Card>
 </CardGroup>
 
@@ -62,6 +62,4 @@ Monitor your data pipelines and integrate with PowerBI
 <Info>
 **Need help getting started?** Contact your implementation team or reach out to [implementations@getkroo.com](mailto:implementations@getkroo.com) for personalized assistance.
 </Info>
-
-
 

--- a/index.mdx
+++ b/index.mdx
@@ -6,7 +6,7 @@ icon: "house"
 
 ## What is Kroo?
 
-Kroo is the data platform for construction. Every tool your team uses — Procore, Sage, P6, ACC — feeds into Kroo automatically. We store it clean, keep it current, and keep it secure. On top of that data, your team can build dashboards, run reports, and ask Kris — Kroo's AI assistant — questions about any project in plain English.
+Kroo is the data platform for construction. Connect any of your tools — PM or ERP Systems, Scheduling Platforms, Prequalifications — and Kroo keeps everything secure, organized, and business ready. Build dashboards and ask Kris anything about your data.
 
 ## Key Benefits
 

--- a/index.mdx
+++ b/index.mdx
@@ -6,22 +6,22 @@ icon: "house"
 
 ## What is Kroo?
 
-Kroo is a **centralized data platform** that transforms how construction teams work with their project data. We automatically ingest, normalize, and flatten data from your existing tools into ready-to-use tables in your data warehouse.
+Kroo is the data platform for construction. Every tool your team uses — Procore, Sage, P6, ACC — feeds into Kroo automatically. We store it clean, keep it current, and keep it secure. On top of that data, your team can build dashboards, run reports, and ask Kris — Kroo's AI assistant — questions about any project in plain English.
 
 ## Key Benefits
 
 <CardGroup cols={2}>
-<Card title="Real-Time Visibility" icon="eye">
-See up-to-date project data across all your systems in one place
+<Card title="One Source of Truth" icon="eye">
+All your construction software feeds into Kroo — no more digging through multiple systems
+</Card>
+<Card title="Ask Kris" icon="sparkles">
+Ask plain-English questions about your project data and get answers instantly
+</Card>
+<Card title="Risk Reduction" icon="shield-check">
+Make informed decisions with accurate, consistent, up-to-date data
 </Card>
 <Card title="Streamlined Workflows" icon="arrow-right">
 Eliminate manual data exports and reduce time spent on reporting
-</Card>
-<Card title="Risk Reduction" icon="shield-check">
-Make informed decisions with accurate, consistent data
-</Card>
-<Card title="Easy Integration" icon="plug">
-Connect your existing tools without changing your workflows
 </Card>
 </CardGroup>
 
@@ -29,22 +29,25 @@ Connect your existing tools without changing your workflows
 
 <Steps>
 <Step title="Connect Your Tools">
-Integrate with your existing construction management platforms (Procore, etc.)
+Integrate with your existing construction management platforms — Procore, Sage, P6, ACC, and more
 </Step>
 <Step title="Automatic Data Processing">
 Kroo continuously syncs and normalizes data from all connected sources
 </Step>
-<Step title="Ready-to-Use Tables">
-Access clean, structured data in your warehouse for reporting and analysis
-</Step>
 <Step title="Build Insights">
 Create dashboards, reports, and analytics with fresh, reliable data
+</Step>
+<Step title="Ask Kris">
+Ask your AI assistant questions about any project, any time — no SQL required
 </Step>
 </Steps>
 
 ## What's Next?
 
 <CardGroup cols={2}>
+<Card title="Meet Kris" href="/meet-kris" icon="sparkles">
+Learn what Kris can do and how to get the most out of it
+</Card>
 <Card title="How Kroo Works" href="/methodology" icon="diagram-project">
 Learn how Kroo processes your construction data
 </Card>
@@ -53,9 +56,6 @@ Query and analyze your project data
 </Card>
 <Card title="Pipeline Status" href="/pipeline-status" icon="chart-line">
 Monitor your data pipelines and integrate with PowerBI
-</Card>
-<Card title="Kris Teams Bot" href="/kris-teams-bot" icon="robot">
-Set up the Kris bot for Microsoft Teams
 </Card>
 </CardGroup>
 

--- a/kroo-mcp-setup.mdx
+++ b/kroo-mcp-setup.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Kris MCP Setup"
-description: "Connect Kris MCP to Microsoft Copilot Studio, Claude, or ChatGPT"
+title: "Kroo MCP Setup"
+description: "Connect Kroo MCP to Microsoft Copilot Studio, Claude, or ChatGPT"
 icon: "plug"
 ---
 
@@ -10,22 +10,22 @@ icon: "plug"
   <Card title="Create or Open" icon="user-plus">
     Start in Copilot Studio, Claude, or ChatGPT.
   </Card>
-  <Card title="Connect Kris" icon="key">
-    Provide the Kris MCP details and authorize with OAuth 2.0.
+  <Card title="Connect Kroo MCP" icon="key">
+    Provide the Kroo MCP details and authorize with OAuth 2.0.
   </Card>
   <Card title="Ask Your Data" icon="sparkles">
     Ask questions and get answers grounded in your authorized Kroo data.
   </Card>
 </CardGroup>
 
-Kris MCP lets supported AI assistants connect to Kris tools over HTTPS. Use the same server URL in each client:
+Kroo MCP lets supported AI assistants connect to Kris tools over HTTPS. Use the same server URL in each client:
 
 ```text
 https://api.getkroo.com/api/v3/mcp
 ```
 
 <Info>
-Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo account and grants access through the browser-based authorization flow.
+Kroo MCP uses OAuth 2.0. During setup, each user signs in with their Kroo account and grants access through the browser-based authorization flow.
 </Info>
 
 
@@ -33,7 +33,7 @@ Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo accoun
 
 <Tabs>
   <Tab title="Copilot Studio">
-    Use these steps to create a new Microsoft Copilot Studio agent and add Kris MCP to it.
+    Use these steps to create a new Microsoft Copilot Studio agent and add Kroo MCP to it.
 
     <Steps>
       <Step title="Open Copilot Studio">
@@ -52,10 +52,10 @@ Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo accoun
         Select **Model Context Protocol**.
       </Step>
 
-      <Step title="Enter the Kris server details">
-        Add the Kris MCP information:
+      <Step title="Enter the Kroo MCP server details">
+        Add the Kroo MCP information:
 
-        - **Server name**: `Kris MCP`
+        - **Server name**: `Kroo MCP`
         - **Server description**: `Use Kris tools to work with authorized construction project data.`
         - **Server URL**: `https://api.getkroo.com/api/v3/mcp`
       </Step>
@@ -72,7 +72,7 @@ Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo accoun
     </Steps>
 
     <Info>
-    Copilot Studio supports the streamable MCP transport. Use the Kris URL above as the server URL.
+    Copilot Studio supports the streamable MCP transport. Use the Kroo MCP URL above as the server URL.
     </Info>
   </Tab>
 
@@ -109,7 +109,7 @@ Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo accoun
     </Steps>
 
     <Info>
-    Claude connects to remote MCP servers from Anthropic's cloud infrastructure, so the server must be reachable over the public internet. The Kris MCP endpoint above is public HTTPS.
+    Claude connects to remote MCP servers from Anthropic's cloud infrastructure, so the server must be reachable over the public internet. The Kroo MCP endpoint above is public HTTPS.
     </Info>
   </Tab>
 
@@ -155,11 +155,11 @@ Kris MCP uses OAuth 2.0. During setup, each user signs in with their Kroo accoun
 
 <AccordionGroup>
   <Accordion title="The OAuth window does not open">
-    Allow browser pop-ups for your AI client, then retry the connection. If the client already saved a failed authorization attempt, remove the Kris MCP server and add it again.
+    Allow browser pop-ups for your AI client, then retry the connection. If the client already saved a failed authorization attempt, remove the Kroo MCP server and add it again.
   </Accordion>
 
   <Accordion title="Chatbot is not querying Kroo">
-    Click the **+** button in the chat, open the app or connector picker, and make sure **Kris MCP** is enabled for that conversation. 
+    Click the **+** button in the chat, open the app or connector picker, and make sure **Kroo MCP** is enabled for that conversation. 
   </Accordion>
 
 

--- a/meet-kris.mdx
+++ b/meet-kris.mdx
@@ -1,10 +1,8 @@
 ---
 title: "Meet Kris"
-description: "Kris is Kroo's AI assistant — ask it anything about your construction project data"
+description: "Kris is Kroo's AI assistant — ask him anything about your construction project data"
 icon: "sparkles"
 ---
-
-Kris is the AI assistant built on top of your Kroo data. Ask questions about your projects in plain English and get answers grounded in your actual records — no SQL, no exports, no digging through spreadsheets.
 
 ## What Kris Can Do
 
@@ -20,12 +18,6 @@ Kris is the AI assistant built on top of your Kroo data. Ask questions about you
   </Card>
   <Card title="Evaluate SOPs & Workflows" icon="list-check">
     Compare what's supposed to happen against what's actually in your data
-  </Card>
-  <Card title="Summarize for Meetings" icon="presentation-screen">
-    Generate project status summaries for OAC meetings, owner updates, and exec reviews
-  </Card>
-  <Card title="Answer Any Project Question" icon="sparkles">
-    Ask anything — Kris knows your data across every connected tool
   </Card>
 </CardGroup>
 
@@ -63,10 +55,10 @@ Kris is the AI assistant built on top of your Kroo data. Ask questions about you
   <Card title="Microsoft Teams" icon="microsoft" href="/kris-teams-bot">
     Ask Kris directly in Teams channels, group chats, or 1:1
   </Card>
-  <Card title="Claude" icon="robot" href="/kris-mcp-setup">
+  <Card title="Claude" icon="robot" href="/kroo-mcp-setup">
     Connect Kris to Claude via MCP for deep project analysis
   </Card>
-  <Card title="ChatGPT" icon="comment" href="/kris-mcp-setup">
+  <Card title="ChatGPT" icon="comment" href="/kroo-mcp-setup">
     Use Kris as a connector inside ChatGPT
   </Card>
 </CardGroup>
@@ -77,7 +69,7 @@ Kris is the AI assistant built on top of your Kroo data. Ask questions about you
   <Card title="Kris Teams Bot" icon="message-bot" href="/kris-teams-bot">
     Install Kris in Microsoft Teams for your organization
   </Card>
-  <Card title="Kris MCP Setup" icon="plug" href="/kris-mcp-setup">
+  <Card title="Kroo MCP Setup" icon="plug" href="/kroo-mcp-setup">
     Connect Kris to Claude, Copilot Studio, or ChatGPT
   </Card>
 </CardGroup>

--- a/meet-kris.mdx
+++ b/meet-kris.mdx
@@ -1,0 +1,74 @@
+---
+title: "Meet Kris"
+description: "Kris is Kroo's AI assistant — ask it anything about your construction project data"
+icon: "sparkles"
+---
+
+Kris is the AI assistant built on top of your Kroo data. Ask it questions about your projects in plain English and get answers grounded in your actual records — no SQL, no exports, no digging through spreadsheets.
+
+## Where You Can Use Kris
+
+<CardGroup cols={3}>
+  <Card title="Microsoft Teams" icon="microsoft" href="/kris-teams-bot">
+    Ask Kris directly in Teams channels, group chats, or 1:1
+  </Card>
+  <Card title="Claude" icon="robot" href="/kris-mcp-setup">
+    Connect Kris to Claude via MCP for deep project analysis
+  </Card>
+  <Card title="ChatGPT" icon="comment" href="/kris-mcp-setup">
+    Use Kris as a connector inside ChatGPT
+  </Card>
+</CardGroup>
+
+## What You Can Ask
+
+Kris can answer questions across all the data Kroo ingests from your connected tools:
+
+<AccordionGroup>
+  <Accordion title="Costs & Budget">
+    - "What's the current budget vs actual for Project Atlas?"
+    - "Show me all open change orders over $50K"
+    - "Which projects have the highest cost variance this month?"
+  </Accordion>
+
+  <Accordion title="RFIs & Submittals">
+    - "How many open RFIs are past their due date on the downtown project?"
+    - "Summarize RFI 042 so I can respond to the architect"
+    - "Which submittals are still pending review?"
+  </Accordion>
+
+  <Accordion title="Schedule & Risk">
+    - "What are the top schedule risks going into next week's OAC meeting?"
+    - "Which activities on the critical path are delayed?"
+    - "Show me procurement items that could impact the schedule"
+  </Accordion>
+
+  <Accordion title="Vendors & Commitments">
+    - "List all commitments for a specific subcontractor"
+    - "What invoices are outstanding for the MEP vendor?"
+    - "Show me commitment change orders approved this week"
+  </Accordion>
+</AccordionGroup>
+
+## Getting Better Answers
+
+The quality of Kris's answers depends on how you frame your questions. Use the **DAC method** — Decompose, Artifacts, Context — to get reliable, decision-ready answers.
+
+<Card title="Prompting Guidelines" icon="wand-magic-sparkles" href="/prompting-guidelines">
+  Learn how to write prompts that get accurate, actionable answers from Kris
+</Card>
+
+## Setup
+
+<CardGroup cols={2}>
+  <Card title="Kris Teams Bot" icon="message-bot" href="/kris-teams-bot">
+    Install Kris in Microsoft Teams for your organization
+  </Card>
+  <Card title="Kris MCP Setup" icon="plug" href="/kris-mcp-setup">
+    Connect Kris to Claude, Copilot Studio, or ChatGPT
+  </Card>
+</CardGroup>
+
+## Support
+
+Questions about Kris or need it enabled for your account? Contact [implementations@getkroo.com](mailto:implementations@getkroo.com).

--- a/meet-kris.mdx
+++ b/meet-kris.mdx
@@ -4,25 +4,32 @@ description: "Kris is Kroo's AI assistant — ask it anything about your constru
 icon: "sparkles"
 ---
 
-Kris is the AI assistant built on top of your Kroo data. Ask it questions about your projects in plain English and get answers grounded in your actual records — no SQL, no exports, no digging through spreadsheets.
+Kris is the AI assistant built on top of your Kroo data. Ask questions about your projects in plain English and get answers grounded in your actual records — no SQL, no exports, no digging through spreadsheets.
 
-## Where You Can Use Kris
+## What Kris Can Do
 
-<CardGroup cols={3}>
-  <Card title="Microsoft Teams" icon="microsoft" href="/kris-teams-bot">
-    Ask Kris directly in Teams channels, group chats, or 1:1
+<CardGroup cols={2}>
+  <Card title="Analyze Costs & Budgets" icon="chart-line">
+    Break down budget vs actual, surface variances, and track commitments across projects
   </Card>
-  <Card title="Claude" icon="robot" href="/kris-mcp-setup">
-    Connect Kris to Claude via MCP for deep project analysis
+  <Card title="Identify Trends" icon="arrow-trend-up">
+    Spot patterns in RFIs, change events, and procurement before they become problems
   </Card>
-  <Card title="ChatGPT" icon="comment" href="/kris-mcp-setup">
-    Use Kris as a connector inside ChatGPT
+  <Card title="Surface Leading Indicators" icon="triangle-exclamation">
+    Find what's trending the wrong way — before it hits the schedule or budget
+  </Card>
+  <Card title="Evaluate SOPs & Workflows" icon="list-check">
+    Compare what's supposed to happen against what's actually in your data
+  </Card>
+  <Card title="Summarize for Meetings" icon="presentation-screen">
+    Generate project status summaries for OAC meetings, owner updates, and exec reviews
+  </Card>
+  <Card title="Answer Any Project Question" icon="sparkles">
+    Ask anything — Kris knows your data across every connected tool
   </Card>
 </CardGroup>
 
 ## What You Can Ask
-
-Kris can answer questions across all the data Kroo ingests from your connected tools:
 
 <AccordionGroup>
   <Accordion title="Costs & Budget">
@@ -50,13 +57,19 @@ Kris can answer questions across all the data Kroo ingests from your connected t
   </Accordion>
 </AccordionGroup>
 
-## Getting Better Answers
+## Where You Can Use Kris
 
-The quality of Kris's answers depends on how you frame your questions. Use the **DAC method** — Decompose, Artifacts, Context — to get reliable, decision-ready answers.
-
-<Card title="Prompting Guidelines" icon="wand-magic-sparkles" href="/prompting-guidelines">
-  Learn how to write prompts that get accurate, actionable answers from Kris
-</Card>
+<CardGroup cols={3}>
+  <Card title="Microsoft Teams" icon="microsoft" href="/kris-teams-bot">
+    Ask Kris directly in Teams channels, group chats, or 1:1
+  </Card>
+  <Card title="Claude" icon="robot" href="/kris-mcp-setup">
+    Connect Kris to Claude via MCP for deep project analysis
+  </Card>
+  <Card title="ChatGPT" icon="comment" href="/kris-mcp-setup">
+    Use Kris as a connector inside ChatGPT
+  </Card>
+</CardGroup>
 
 ## Setup
 

--- a/prompting-guidelines.mdx
+++ b/prompting-guidelines.mdx
@@ -1,0 +1,193 @@
+---
+title: "Prompting Guidelines"
+description: "Use DAC prompts to get clearer construction answers from Kris and other AI tools"
+icon: "wand-magic-sparkles"
+---
+<CardGroup cols={3}>
+  <Card title="Decompose" icon="diagram-project">
+    Break the request into a task list that Kris should explore and perform before providing an answer.
+  </Card>
+  <Card title="Artifacts" icon="file-lines">
+    Add the source material for Kris to mirror results and structure, such as sample emails or generated reports.
+  </Card>
+  <Card title="Context" icon="circle-info">
+    Explain the project, date range, audience, constraints, and decision you need to make.
+  </Card>
+</CardGroup>
+
+## The DAC Template
+
+Copy this structure when you need a reliable answer:
+
+
+
+<Tabs>
+<Tab title="Open AP/AR Aging">
+```text
+Goal:
+Show open accounts payable and accounts receivable by aging bucket.
+
+DAC:
+1. Decompose the analysis into AP invoices, AR invoices, open balances, aging buckets, project/vendor/customer breakdowns, and exclusions.
+2. Use these artifacts: AP invoice table, AR invoice table, payment records, vendor list, customer list, and project list.
+3. Context: This is for a construction finance review. Bucket open invoices into 0-30, 31-60, 61-90, and 90+ days. Exclude void invoices from every total.
+
+Output:
+Return a table with columns: Aging Bucket, Open AP, Open AR, Net Position, Invoice Count, and Notes. Then list any assumptions, including whether aging is based on due date or invoice date.
+```
+</Tab>
+
+<Tab title="RFI Summary">
+```text
+Goal:
+Summarize RFI 042 so the PM can prepare a response to the architect.
+
+DAC:
+1. Decompose the issue into design intent, affected drawings/specs, impacted trades, schedule risk, and open questions.
+2. Use these artifacts: RFI text, drawing A-301, spec section 07 21 00, and the May 12 coordination meeting notes.
+3. Context: This is an occupied hospital renovation. Work is in Area B. The response should help the PM ask the design team for a clear decision.
+
+Output:
+Return 5 bullets: issue, likely interpretation, impacted trades, risks, and questions to ask. Cite the artifact used for each point.
+```
+</Tab>
+
+<Tab title="Schedule Risk">
+```text
+Goal:
+Identify the top schedule risks for next week's OAC meeting.
+
+DAC:
+1. Decompose the analysis into critical activities, delayed predecessors, missing decisions, procurement risks, and trade coordination issues.
+2. Use these artifacts: current P6 lookahead, RFI log, submittal log, procurement log, and last week's meeting minutes.
+3. Context: Focus on work planned in the next 3 weeks. Audience is owner, architect, and GC leadership.
+
+Output:
+Return the top 5 risks with owner, evidence, likely impact, and recommended next action.
+```
+</Tab>
+</Tabs>
+
+
+<Tip>
+If the answer matters for cost, schedule, safety, contract terms, or client communication, ask the AI to list assumptions and missing information before giving the final recommendation.
+</Tip>
+
+## Best Practices
+
+### 1. Ask for the thinking path, not hidden reasoning
+
+Use a clear process:
+
+```text
+Before answering, break this into the checks you need to perform. Then give the final answer in the requested format.
+```
+
+This helps the AI avoid jumping straight to a confident but incomplete answer.
+
+### 2. Name the artifacts clearly
+
+Be specific about what the AI should use:
+
+| Instead of | Use |
+|------------|-----|
+| "Look at the project docs" | "Use RFI log, submittal log, drawing A-401, and spec section 09 91 00" |
+| "Analyze costs" | "Use the change event export, commitment log, and approved budget view" |
+| "Check schedule" | "Use the current P6 file, 3-week lookahead, and procurement log" |
+
+### 3. Define the output before the AI starts
+
+Construction teams usually need decision-ready formats:
+
+- A table for reviews, comparisons, and logs
+- A short narrative for owner updates or change events
+- Bullets for meeting prep
+- A checklist for field follow-up
+- A risk register for leadership review
+
+### 4. Set boundaries
+
+Tell the AI what not to do:
+
+```text
+Do not invent contract requirements.
+Do not include void invoices in aging totals.
+Do not make legal conclusions.
+Do not assume schedule impact unless it is supported by the artifacts.
+```
+
+### 5. Require missing information
+
+Good construction answers should show gaps:
+
+```text
+If information is missing, list what is missing, why it matters, and who likely owns the answer.
+```
+
+### 6. Use examples when tone matters
+
+If you want the AI to match your company's communication style, provide 1-2 examples:
+
+```text
+Match this tone: factual, concise, and owner-facing.
+
+Example:
+"The team is reviewing the added scope against the current drawings and will confirm cost and schedule exposure after subcontractor pricing is received."
+```
+
+## Prompt Quality Checklist
+
+Before sending a prompt, check for these five items:
+
+<Steps>
+<Step title="Decision">
+Is it clear what decision, draft, summary, or analysis you need?
+</Step>
+
+<Step title="Artifacts">
+Did you include or name the source records the AI should rely on?
+</Step>
+
+<Step title="Context">
+Did you include project, trade, dates, audience, and constraints?
+</Step>
+
+<Step title="Format">
+Did you define the output format?
+</Step>
+
+<Step title="Gaps">
+Did you ask for assumptions, missing information, and next steps?
+</Step>
+</Steps>
+
+## Common Fixes
+
+| If the answer is... | Improve the prompt by... |
+|---------------------|---------------------------|
+| Too generic | Add project context, role of the audience, and source artifacts |
+| Too long | Specify the exact number of bullets, rows, or paragraphs |
+| Too confident | Ask for assumptions, evidence, confidence level, and missing information |
+| Missing key records | Name the exact RFIs, specs, drawings, logs, or tables to use |
+| Hard to act on | Request owner, due date, risk, and next action columns |
+
+## A Strong Starting Prompt
+
+```text
+I need help preparing for a construction project review.
+
+Goal:
+Identify the most important open issues that could affect cost, schedule, or owner decisions.
+
+DAC:
+1. Decompose the review into RFIs, submittals, procurement, schedule, change events, and field coordination.
+2. Use these artifacts: [paste or attach current logs, meeting notes, schedule export, and cost report].
+3. Context: [project type], [phase], [audience], [date range], [known constraints].
+
+Output:
+Return a table with columns: Issue, Source Artifact, Why It Matters, Owner, Due Date, Recommended Next Action. Then list assumptions and missing information.
+```
+
+<Warning>
+Only share project data in tools approved by your company. For sensitive contract, personnel, financial, or safety information, follow your internal data handling policies.
+</Warning>


### PR DESCRIPTION
## Summary

- Rewrites "What is Kroo?" with the approved copy leading with the platform value prop
- Adds **Meet Kris** page — covers what Kris can do (analyze costs, identify trends, leading indicators, SOPs, meeting summaries), example questions by category, where to use Kris, and setup links
- Adds **Prompting Guidelines** page from the `ki-ai-prompting-guidelines` branch (DAC method with construction examples)
- Adds a **Kris** group to the Platform tab in navigation so it's front and center for new users

## Test plan

- [ ] Welcome page "What is Kroo?" reads correctly
- [ ] Meet Kris page renders cards, accordions, and links correctly
- [ ] Prompting Guidelines page renders tabs and steps correctly
- [ ] Kris group appears in Platform tab sidebar
- [ ] All internal links (kris-teams-bot, kris-mcp-setup, prompting-guidelines) resolve

https://claude.ai/code/session_015QquSLAriAMQf2Znq2HFBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015QquSLAriAMQf2Znq2HFBZ)_